### PR TITLE
fixed comments on yang module

### DIFF
--- a/asap-example.json
+++ b/asap-example.json
@@ -3,7 +3,7 @@
         {
             "variant": "1.0",
             "revision": {
-                "notBefore": "2021-10-16T00:00:00.00000Z",
+                "notBefore": 1742330340,
                 "location": 
                     "https://capserver.example.org/capserver/capdoc.json"
             },
@@ -65,7 +65,7 @@
                 ],
                 "caller-id": {
                     "e164-format": true,
-                    "preferred-method": "P-Asserted-Identity"
+                    "preferred-method": "FROM"
                 },
                 "num-ranges": [
                     {
@@ -88,13 +88,19 @@
                 ]
             },
             "media": {
-                "media-type-audio": {
-                    "media-format": [
-                        "PCMU;rate=8000;ptime=20",
-                        "G729;rate=8000;annexb=yes",
-                        "G722;rate=8000;bitrate=56k,64k"
-                    ]
-                },
+                "media-type-audio": [
+                    {
+                        "media-format": "PCMU",
+                        "rate": 8000,
+                        "ptime": 20
+                    },
+                    {
+                        "media-format": "G722",
+                        "rate": 8000,
+                        "ptime": 20,
+                        "param": "annexb"
+                    }
+                ],
                 "fax": {
                     "protocol": [
                         "t38",
@@ -120,7 +126,7 @@
                     "version": ["1.0", "1.2", "1.3"]
                 },
                 "media-security": {
-                    "key-management": "SDES;DTLS-SRTP,version=1.2"
+                    "key-management": ["SDES", "DTLS-SRTP"]
                 },
                 "cert-location": 
                     "https://sipserviceprovider.com/certificateList.pem",

--- a/ietf-sip-auto-peering@2025-01-30.tree
+++ b/ietf-sip-auto-peering@2025-01-30.tree
@@ -1,20 +1,25 @@
 module: ietf-sip-auto-peering
-  +--rw peering-info* [index]
-     +--rw index             uint16
+  +--rw peering-info
      +--rw variant           enumeration
      +--rw revision
-     |  +--rw not-before    string
-     |  +--rw location      string
+     |  +--rw not-before    uint32
+     |  +--rw location      uri
      +--rw transport-info
      |  +--rw transport*        enumeration
-     |  +--rw registrar*
+     |  +--rw registrar* [host port]
+     |  |  +--rw host    union
+     |  |  +--rw port    inet:port-number
      |  +--rw realms* [name]
      |  |  +--rw name        string
      |  |  +--rw username?   string
      |  |  +--rw password?   ianach:crypt-hash
-     |  +--rw call-control*
+     |  +--rw call-control* [host port]
+     |  |  +--rw host    union
+     |  |  +--rw port    inet:port-number
      |  +--rw dns*              inet:ip-address
-     |  +--rw outbound-proxy?
+     |  +--rw outbound-proxy* [host port]
+     |     +--rw host    union
+     |     +--rw port    inet:port-number
      +--rw call-specs
      |  +--rw early-media?         boolean
      |  +--rw signaling-forking?   boolean
@@ -28,8 +33,11 @@ module: ietf-sip-auto-peering
      |     +--rw count?   uint16
      |     +--rw value*   string
      +--rw media
-     |  +--rw media-type-audio
-     |  |  +--rw media-format*   string
+     |  +--rw media-type-audio* [media-format]
+     |  |  +--rw media-format    enumeration
+     |  |  +--rw rate?           uint8
+     |  |  +--rw ptime?          uint8
+     |  |  +--rw param?          string
      |  +--rw fax
      |  |  +--rw protocol*   enumeration
      |  +--rw rtp
@@ -46,10 +54,10 @@ module: ietf-sip-auto-peering
      |  |  +--rw secure?    boolean
      |  |  +--rw version*   enumeration
      |  +--rw media-security
-     |  |  +--rw key-management?   string
+     |  |  +--rw key-management?   enumeration
      |  +--rw cert-location?               string
      |  +--rw secure-telephony-identity
      |     +--rw stir-compliance?   boolean
      |     +--rw cert-delegation?   boolean
-     |     +--rw acme-directory?    string
+     |     +--rw acme-directory?    uri
      +--rw extensions*       string

--- a/ietf-sip-auto-peering@2025-03-04.yang
+++ b/ietf-sip-auto-peering@2025-03-04.yang
@@ -1,13 +1,18 @@
 module ietf-sip-auto-peering {
+  yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-sip-auto-peering";
   prefix "peering";
 
   import ietf-inet-types {
     prefix "inet";
+    reference
+      "RFC 6991: Common YANG Data Types";
   }
 
   import iana-crypt-hash {
     prefix "ianach";
+    reference
+      "RFC 7317:  A YANG Data Model for System Management";
   }
 
   organization
@@ -30,105 +35,114 @@ module ietf-sip-auto-peering {
     "Data model for encoding SIP Service Provider Capability Set
 
     Copyright (c) 2025 IETF Trust and the persons identified as
-    authors of the code.  All rights reserved.
+     authors of the code.  All rights reserved.
 
-    Redistribution and use in source and binary forms, with or
-    without modification, is permitted pursuant to, and subject
-    to the license terms contained in, the Simplified BSD License
-    set forth in Section 4.c of the IETF Trust's Legal Provisions
-    Relating to IETF Documents
-    (http://trustee.ietf.org/license-info).
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Revised BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
 
     This version of this YANG module is part of RFC XXXX
-    (https://www.rfc-editor.org/info/rfcXXXX); see
-    the RFC itself for full legal notices.
-
+     (https://www.rfc-editor.org/info/rfcXXXX); see the RFC itself
+     for full legal notices.
+    
     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
-    NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
-    'MAY', and 'OPTIONAL' in this document are to be interpreted as
-      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
-    they appear in all capitals, as shown here.";
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
 
   revision 2025-03-04 {
     description "Initial version";
     reference
-      "RFC XXXX: Automatic Peering for SIP Trunks";
+      "NOTE TO RFC EDITOR: Please replace 'RFC XXXX' with the actual
+      RFC number of this document when published, and delete this
+      sentence. Also replace the revision with the date of publication
+      of this document.
+      RFC XXXX: Automatic Peering for SIP Trunks";
+  }
+
+  typedef uri {
+    type string;
+    description "Type for a Uniform Resource Identifier";
+    reference
+      "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax";
   }
 
   grouping entity {
-    description "Grouping that provides a reusable list named 'entity', 
-      with each entry containing a host and a port.";
+    description "Grouping that provides a reusable list named
+      'entity', with each entry containing a host and a port.";
 
-      leaf host {
-        type union {
-          type inet:ip-address;
-          type inet:domain-name; 
-        }
-        description "IP Address or host name of the entity";
+    leaf host {
+      type union {
+        type inet:ip-address;
+        type inet:domain-name; 
       }
-
-      leaf port {
-        type inet:port-number;
-        description "Entity's port number (e.g. 5060).";
-      }
-  }
-
-  list peering-info {
-    key index;
-    max-elements 1;
-    description "A container for all the other nodes in the YANG module;
-      the peering-info node is akin to the root element of a JSON document.";
-
-    leaf index {
-      type uint16;
-      description "Index for the peering-info set.";
+      description "IP Address or host name of the entity";
     }
 
+    leaf port {
+      type inet:port-number;
+      description "Entity's port number (e.g. 5060).";
+    }
+  }
+
+  container peering-info {
+    description "A container for all the other nodes in the YANG
+      module; the peering-info node is akin to the root element of
+      a JSON document.";
+
     leaf variant {
-      type enumeration{
-        enum 1.0 {
-          description "Variant 1.0 of the capability set document is defined
-            in this draft";
+      type enumeration {
+        enum v1_0 {
+          description "Variant 1.0 of the capability set document is
+            defined in this draft";
         }
       }
       mandatory true;
       description "A node that identifies the version number of the
-        capability set document. This draft defines the parameters for 
-        variant 1.0; future specifications might define a richer parameter
-        set, in which case the variant must be changed to 2.0, 3.0 and so on.
-        Future extensions to the capability set document MUST also ensure
-        that the corresponding YANG module is defined.";
+        capability set document. This draft defines the parameters
+        for variant 1.0; future specifications might define a richer
+        parameter set, in which case the variant must be changed to
+        2.0, 3.0 and so on. Future extensions to the capability set
+        document MUST also ensure that the corresponding YANG module
+        is defined.";
     }
 
     container revision {
-      description "A container that encapsulates information regarding the
-        availability of a new version of the capability set document for the
-        enterprise.";
+      description "A container that encapsulates information
+        regarding the availability of a new version of the
+        capability set document for the enterprise.";
 
       leaf not-before {
-        type string;
+        type uint32;
         mandatory true;
-        description "A node that identifies the data and time at which the
-          parameters in this capability set documents are activated or
-          considered valid. This node has been set to mandatory as the it
-          is the service provider's responsibility to inform when new peering
-          settings take effect. Without being aware of a start time, the
+        description "A node that identifies the epoch time at
+          which the parameters in this capability set document are
+          activated or considered valid. This node has been set to
+          mandatory as it is the service provider's 
+          responsibility to inform when new peering settings take
+          effect. Without being aware of a start time, the
           enterprise network will experience failures.";
       }
 
       leaf location {
-        type string;
+        type uri;
         mandatory true;
-        description "A node that identifies the URL of a new revision of the
-          service provider capability set document. Without this URL, an
-          enterprise network wouldn't be aware of changes that have occured
-          in the service provider network.";
+        description "A node that identifies the URL of a new
+          revision of the service provider capability set document.
+          Without this URL, an enterprise network wouldn't be aware
+          of changes that have occurred in the service provider
+          network.";
       }
     }
 
     container transport-info {
-      description "A container that encapsulates transport characteristics of
-        SIP sessions between enterprise and service provider networks.";
+      description "A container that encapsulates transport
+        characteristics of SIP sessions between enterprise and
+        service provider networks.";
 
       leaf-list transport {
         type enumeration {
@@ -142,144 +156,138 @@ module ietf-sip-auto-peering {
             description "User Datagram Protocol";
           }
         }
-        mandatory true;
+        min-elements 1;
         description "A list that enumerates the different Transport
-          Layer protocols supported by the SIP service provider. Valid
-          transport layer protocols include: UDP, TCP and TLS";
+          Layer protocols supported by the SIP service provider.
+          Valid transport layer protocols include: UDP, TCP and TLS";
       }
 
-      leaf-list registrar {
+      list registrar {
+        key "host port";
         uses entity;
         max-elements 3;
-        description "A list that specifies the transport address of one
-          or more registrar servers in the service provider network. The
-          transport address of the registrar can be provided using a
-          combination of a valid IP address and port number, or a subdomain
-          of the SIP service provider network, or the fully qualified domain
-          name (FQDN) of the SIP service provider network. If the transport
-          address of a registrar is specified using either a subdomain or a
-          fully qualified domain name, the DNS element must be populated with
-          one or more valid DNS server IP addresses.";
+        description "A list that specifies the transport address of
+          one or more registrar servers in the service provider
+          network. The transport address of the registrar can be
+          provided using a combination of a valid IP address and
+          port number, or a subdomain of the SIP service provider
+          network, or the fully qualified domain name (FQDN) of the
+          SIP service provider network. If the transport address of
+          a registrar is specified using either a subdomain or a
+          fully qualified domain name, the DNS element must be
+          populated with one or more valid DNS server IP
+          addresses.";
       }
 
       list realms {
         key "name";
-        description "A container that encapsulates the set of realms or
-          protection domains the SIP service provider is responsible for.";
+        description "A container that encapsulates the set of realms
+          or protection domains the SIP service provider is
+          responsible for.";
 
         leaf name {
           type string;
-          mandatory true;
-          description "A node specifying the SIP service provider realm
-            or protection domain. This node is encoded as a string the value
-            of this node must be identical to the value of the “realm”
-            parameter in a WWW-Authenticate header field that the SIP service
-            provider might send in response to requests that do not contain a
-            valid Authorisation header field. ";
+          // mandatory true;
+          description "A node specifying the SIP service provider
+            realm or protection domain. This node is encoded as a
+            string; the value of this node must be identical to the
+            value of the 'realm' parameter in a WWW-Authenticate
+            header field that the SIP service provider might send in
+            response to requests that do not contain a valid
+            Authorisation header field.";
         }
 
         leaf username {
           type string;
-          description "A node that encodes the username for the given realm.
-            The username is one of many inputs used by the enterprise network
-            in generating the response parameter of the Authorization header
-            field.";
+          description "A node that encodes the username for the
+            given realm. The username is one of many inputs used by
+            the enterprise network in generating the response
+            parameter of the Authorization header field.";
         }
 
         leaf password {
           type ianach:crypt-hash;
-          description "A node that encodes the password for the given realm.
-            The password is one of many inputs used by the enterprise
-            network in generating the response parameter of the 
-            Authorization header field. The password is stored as a
-            cryptographic hash."
-          ;
+          description "A node that encodes the password for the
+            given realm. The password is one of many inputs used by
+            the enterprise network in generating the response
+            parameter of the Authorization header field. The
+            password is stored as a cryptographic hash.";
         }
       }
 
-      leaf-list call-control {
+      list call-control {
+        key "host port";
         uses entity;
         max-elements 3;
-        description "A list that specifies the transport address of the
-          call server(s) in the service provider network. The enterprise
-          network must use an applicable transport protocol in conjunction
-          with the call control server(s) transport address when transmitting
-          call setup requests. The transport address of a call server(s)
-          within the service provider network can be specified using a
-          combination of a valid IP address and port number, or a subdomain
-          of the SIP service provider network, or a fully qualified domain
-          name of the SIP service provider network. If the transport address
-          of a call control server(s) is specified using either a subdomain
-          or a fully qualified domain name, the DNS element must be populated
-          with one or more valid DNS server IP addresses. The transport
-          address specified in this element can also serve as the target for
-          non-call requests such as SIP OPTIONS.";
+        description "A list that specifies the transport address of
+          the call server(s) in the service provider network. The
+          enterprise network must use an applicable transport
+          protocol in conjunction with the call control server(s)
+          transport address when transmitting call setup requests.
+          The transport address specified in this list can also
+          serve as the target for non-call requests such as SIP
+          OPTIONS.";
       }
 
       leaf-list dns {
         type inet:ip-address;
         max-elements 2;
-        description "A list that encodes the IP address of one or more
-          DNS servers hosted by the SIP service provider. If the enterprise
-          network is unaware of the IP address, port number, and transport
-          protocol of servers within the service provider network (for
-          example, the registrar and call control server), it must use DNS
-          NAPTR and SRV. Alternatively, if the enterprise network has the 
-          fully qualified domain name of the SIP service provider network, it
-          must use DNS to resolve the said FQDN to an IP address. The dns
-          element encodes the IP address of one or more DNS servers hosted in
-          the service provider network. If however, either the registrar or
-          call-control elements or both are populated with a valid IP address
-          and port pair, the dns element must be set to ::/0.";
+        description "A list that encodes the IP address of one or
+          more DNS servers hosted by the SIP service provider. If
+          the enterprise network is unaware of the IP address, port
+          number, and transport protocol of servers within the
+          service provider network (for example, the registrar and
+          call control server), it must use DNS NAPTR and SRV.
+          Alternatively, if the enterprise network has the fully
+          qualified domain name of the SIP service provider network,
+          it must use DNS to resolve the said FQDN to an IP address.
+          The dns element encodes the IP address of one or more DNS
+          servers hosted in the service provider network. If however,
+          either the registrar or call-control lists or both are
+          populated with a valid IP address and port pair, the dns
+          element must be set to ::/0.";
       }
 
-      leaf outbound-proxy {
+      list outbound-proxy {
+        key "host port";
         uses entity;
-        description "A list that specifies the transport address of one
-          or more outbound proxies. The transport address can be specified by
-          using a combination of an IP address and a port number, a subdomain
-          of the SIP service provider network, or a fully qualified domain
-          name and port number of the SIP service provider network. If the
-          outbound-proxy sub-element is populated with a valid transport
-          address, it represents the default destination for all outbound
-          SIP requests and therefore, the registrar and call-control elements
-          must be populated with the quadruple octet of 0.0.0.0";
+        description "A list that specifies the transport address of
+          one or more outbound proxies. The transport address can be
+          specified by using a combination of an IP address and a
+          port number, a subdomain of the SIP service provider
+          network, or a fully qualified domain name and port number
+          of the SIP service provider network. If the outbound-proxy
+          list is populated with a valid transport address, it
+          represents the default destination for all outbound SIP
+          requests and therefore, the registrar and call-control
+          lists must be populated with the quadruple octet of
+          0.0.0.0";
       }
     }
 
     container call-specs {
-      description "A container that encapsulates information about call
-        specifications, restrictions and additional handling criteria for
-        SIP calls between the enterprise and service provider network.";
+      description "A container that encapsulates information about
+        call specifications, restrictions and additional handling
+        criteria for SIP calls between the enterprise and service
+        provider network.";
 
       leaf early-media {
         type boolean;
-        description "A node that specifies whether the service provider
-          network is expected to deliver in-band announcements/tones before
-          call connect. The 'P-Early-Media' header field can be used to
-          indicate pre-connect delivery of tones and announcements on a
-          per-call basis. However, given that signalling and media could
-          traverse a large number of intermediaries with varying capabilities
-          (in terms of handling of the 'P-Early-Media' header field) within
-          the enterprise, such devices can be appropriately configured for
-          media cut through if it is known before-hand that early media is
-          expected for some or all of the outbound calls. This element is a
-          boolean type, where a value of true signifies that the service
-          provider is capable of early media. A value of false signifies that
-          the service provider is not expected to generate early media.";
+        description "A node that specifies whether the service
+          provider network is expected to deliver in-band
+          announcements/tones before call connect. A value of true
+          signifies that the service provider is capable of early
+          media, whereas false signifies otherwise.";
       }
 
       leaf signaling-forking {
         type boolean;
-        description "A node that specifies whether outbound call requests from
-          the enterprise might be forked on the service provider network that
-          MAY lead to multiple early dialogs. This information would be useful
-          to the enterprise network in appropriately handling multiple early
-          dialogs reliably and in enforcing local policy. This element is a
-          boolean type, where a value of true signifies that the service
-          provider network can potentially fork outbound call requests from
-          the enterprise. A value of false indicates that the service provider
-          will not fork outbound call requests.";
+        description "A node that specifies whether outbound call
+          requests from the enterprise might be forked on the
+          service provider network that may lead to multiple early
+          dialogs. A value of true indicates the service provider
+          network can potentially fork outbound call requests,
+          whereas false indicates it will not.";
       }
 
       leaf-list supported-methods {
@@ -327,68 +335,44 @@ module ietf-sip-auto-peering {
             description "Update session parameters within a dialog.";
           }
         }
-        description "A list that specifies the various SIP methods supported
-          by the SIP service provider. The list of supported methods help to
-          appropriately configure various devices within the enterprise 
-          network. For example, if the service provider enumerates support
-          for the OPTIONS method, the enterprise network could periodically
-          send OPTIONS requests as a keep-alive mechanism.";
+        description "A list that specifies the various SIP methods
+          supported by the SIP service provider.";
       }
 
       container caller-id {
-        description "A container that encodes the preferences of SIP Service
-          Providers in terms of calling number presentation by the enterprise
-          network. Certain ITSPs require that the calling number be formatted
-          in E.164, whereas others place no such restrictions. Additionally,
-          some ITSPs require that the calling number be included in a specific
-          SIP header field, for example, the P-Asserted-ID header field or the
-          From header field, whereas others place no restrictions on the
-          specific SIP header field used to convey the calling number.";
+        description "A container that encodes the preferences of
+          SIP Service Providers in terms of calling number
+          presentation by the enterprise network.";
 
         leaf e164-format {
           type boolean;
-          description "A node that indicates whether the service provider
-            requires the enterprise network to normalize the calling number
-            into E.164 format. This node is of type boolean. A value of true
-            mandates the enterprise network to format calling numbers to E.164
-            format, while a false leaves the formatting of the calling number
-            up to the enterprise network.";
+          description "A node that indicates whether the service
+            provider requires the enterprise network to normalize
+            the calling number into E.164 format.";
         }
 
         leaf preferred-method {
           type enumeration {
-            enum P-Asserted-Identity {
-              description "Use the 'P-Asserted-Identity' header to determine
-              remote party identity.";
+            enum P_ASSERTED_IDENTITY {
+              description "Use the 'P-Asserted-Identity' header to
+                determine remote party identity.";
             }
-            enum From {
-              description "Use the 'From' header to determine remote party
-              identity.";
+            enum FROM {
+              description "Use the 'From' header to determine remote
+                party identity.";
             }
           }
-          description "A node that specifies which SIP header MUST be used by
-            the enterprise network to communicate caller information. The
-            value of this node is a string that contains the name of the SIP
-            header required to carry caller information.";
+          description "A node that specifies which SIP header MUST
+            be used by the enterprise network to communicate caller
+            information.";
         }
       }
 
       list num-ranges {
         key index;
-        description "A list that specifies the Direct Inward Dial (DID)
-          number range allocated to the enterprise network by the SIP service
-          provider. The DID number ranges allocated by the service provider to
-          the enterprise network might be a contiguous or a non-contiguous
-          block. The number ranges allocated to an enterprise can be
-          communicated as a value or as a reference. For large enterprise
-          networks, the size of the DID range might run into several hundred
-          numbers. For situations in which the enterprise is allocated a large
-          DID number range or a non-contiguous number range it is RECOMMENDED
-          that the SIP service provider communicate this information by
-          reference, that is, through a URL. The enterprise network is
-          required to de-reference this URL in order to obtain the DID number
-          ranges allocated by the SIP service provider. Refer to the example
-          provided in Section 9.1.";
+        description "A list that specifies the Direct Inward Dial
+          (DID) number range allocated to the enterprise network by
+          the SIP service provider.";
 
         leaf index {
           type uint16;
@@ -401,236 +385,158 @@ module ietf-sip-auto-peering {
               description "Numbers specified as a range.";
             }
             enum collection {
-              description "Numbers specified in the form of a collection.";
+              description "Numbers specified in the form of a 
+                collection.";
             }
             enum reference {
               description "Number range available at a URL.";
             }
           }
-          description "A node that indicates whether the DID range is
-            communicated by value or by reference. It can have a value of
-            'range', 'collection' or 'reference'.";
+          description "Indicates whether the DID range is
+            communicated by value or by reference.";
         }
 
         leaf count {
           when "../type = 'range' or ../type = 'collection'";
           type uint16;
-          description "A node that indicates the size of the DID number
-            range. The number range may be contiguous or non-contiguous. This
-            leaf node MUST NOT be included when using the 'reference'
-            num-ranges type value.";
+          description "Indicates the size of the DID number range.
+            This leaf MUST NOT be included when using the
+            'reference' type.";
         }
 
         leaf-list value {
           type string;
-          description "A list that encapsulates the DID number range allocated
-            to the enterprise. If the num-ranges 'type' is set to 'range' or
-            'collection', the 'count' node MUST have a valid, non-zero,
-            positive integer. If the num-ranges 'type' value is set to
-            'range', then, the number in this field represents the first
-            phone number of a DID range allocated to the enterprise. The value
-            of subsequent numbers of the given DID range are obtained by
-            adding one to the value of this field. The number of times we need
-            to add one is indicated by the 'count' field.";
+          description "A list that encapsulates the DID number range
+            allocated to the enterprise.";
         }
       }
     }
 
     container media {
-      description "A container that is used to collectively encapsulate the
-        characteristics of UDP-based audio streams. A future extension to this
-        draft may extend the media container to describe other media types.
-        The media container is also used to encapsulate basic information
-        about Real-Time Transport Protocol (RTP) and Real-Time Transport
-        Control Protocol (RTCP) from the perspective of the service provider
-        network. At the time of writing this specification, video media
-        streams aren't exchanged between enterprise and service provider SIP
-        networks.";
+      description "A container used to encapsulate the
+        characteristics of UDP-based audio streams and basic
+        RTP/RTCP information.";
 
-      container media-type-audio {
-        description "A container for the mediaFormat list. This container
-          collectively encapsulates the various audio media formats
-          supported by the SIP service provider.";
+      list media-type-audio {
+        key "media-format";
+        description "A list of media types and
+          parameters necessary to set up media between the
+          enterprise and service provider.";
 
-        leaf-list media-format {
+        leaf media-format {
+          type enumeration {
+            enum PCMU {
+              description "PCMU format.";
+            }
+            enum G722 {
+              description "G722 format.";
+            }
+          }
+          description "The audio media format.";
+        }
+
+        leaf rate {
+          type uint8;
+          description "Sampling rate in Hz.";
+        }
+
+        leaf ptime {
+          type uint8;
+          description "Packetization time in milliseconds.";
+        }
+
+        leaf param {
           type string;
-          description "A list encoding the various audio media formats
-          supported by the SIP service provider. The relative ordering
-          of different media format leaf nodes from left to right indicates
-          preference from the perspective of the service provider. Each
-          mediaFormat node begins with the encoding name of the media format,
-          which is the same encoding name as used in the 'RTP/AVP' and
-          'RTP/SAVP' profiles. The encoding name is followed by required and
-          optional parameters for the given media format as specified when
-          the media format is registered [@RFC4855]. Given that the
-          parameters of media formats can vary from one communication session
-          to another, for example, across two separate communication
-          sessions, the packetization time (ptime) used for the PCMU media
-          format might vary from 10 to 30 ms, the parameters included in the
-          format element must be the ones that are expected to be invariant
-          from the perspective of the service provider. Providing information
-          about supported media formats and their respective parameters,
-          allows enterprise networks to configure the media plane
-          characteristics of various devices such as endpoints and
-          middleboxes. The encoding name, one or more required parameters,
-          one or more optional parameters are all separated by a semicolon.
-          The formatting of a given media format parameter, must follow the
-          formatting rules as specified for that media format.";
+          description "Optional parameter for additional media
+            details.";
         }
       }
 
       container fax {
-        description "A container that encapsulates the fax protocol(s)
-          supported by the SIP service provider. The fax container encloses
-          a list (protocol) that enumerates whether the service provider
-          supports t38 relay, protocol-based fax passthrough or both. The
-          relative ordering of nodes within the lists indicates
-          preference.";
+        description "Encapsulates the fax protocol(s) supported by
+          the SIP service provider.";
 
         leaf-list protocol {
           type enumeration {
-            enum "pass-through" {
+            enum pass_through {
               description "Protocol-based fax passthrough.";
             }
-
-            enum "t38" {
+            enum t38 {
               description "T38 relay.";
             }
           }
           max-elements 2;
-          description "List indicating the different fax
-          protocols supported by the service provider.";
+          description "List indicating the different fax protocols
+            supported by the service provider.";
         }
       }
 
       container rtp {
-        description "A container that encapsulates generic characteristics
-          of RTP sessions between the enterprise and service provider network.
-          This node is a container for the 'rtp-trigger' and 'symmetric-rtp'
-          nodes.";
+        description "Encapsulates generic characteristics of RTP
+          sessions.";
 
         leaf rtp-trigger {
           type boolean;
-          description "A node indicating whether the SIP service provider
-            network always expects the enterprise network to send the first
-            RTP packet for an established communication session. This
-            information is useful in scenarios such as 'hairpinned' calls,
-            in which the caller and callee are on the service provider network
-            and because of sub-optimal media routing, an enterprise device
-            such as an SBC is retained in the media path. Based on the
-            encoding of this node, it is possible to configure enterprise
-            devices such as SBCs to start streaming media (possibly filled
-            with silence payloads) toward the address:port tuples provided
-            by caller and callee. This node is a boolean type. A value of
-            true indicates that the service provider expects the enterprise
-            network to send the first RTP packet, whereas a value of false
-            indicates that the service provider network does not require the
-            enterprise network to send the first media packet. While the
-            practise of preserving the enterprise network in a hairpinned call
-            flow is fairly common, it is recommended that SIP service
-            providers avoid this practise. In the context of a hairpinned
-            call, the enterprise device retained in the call flow can easily
-            eavesdrop on the conversation between the offnet parties.";
+          description "Indicates whether the service provider
+            expects the enterprise network to send the first RTP
+            packet.";
         }
 
         leaf symmetric-rtp {
           type boolean;
-          description "A node indicating whether the SIP service provider
-            expects the enterprise network to use symmetric RTP as defined
-            in [@]RFC4961]. Enforcement of this requirement by service
-            providers on enterprise networks is typically useful in scenarios
-            such as media latching [@RFC7362]. This node is a boolean type,
-            a value of true indicates that the service provider expects the
-            enterprise network to use symmetric RTP, whereas a value of false
-            indicates that the enterprise network can use asymmetric RTP.";
+          description "Indicates whether the service provider
+            expects the use of symmetric RTP.";
         }
       }
 
       container rtcp {
-        description "A container that encapsulates generic characteristics of
-          RTCP sessions between the enterprise and service provider network.
-          This node is a container for the 'rtcp-feedback' and
-          'symmetric-rtcp' nodes.";
+        description "Encapsulates generic characteristics of RTCP
+          sessions.";
 
         leaf symmetric-rtcp {
           type boolean;
-          description "A node indicating whether the SIP service provider
-            expects the enterprise network to use symmetric RTCP as defined
-            in [@RFC4961]. This node is a boolean type, a value of true
-            indicates that the service provider expects symmetric RTCP
-            reports, whereas a value of false indicates that the enterprise
-            can use asymmetric RTCP.";
+          description "Indicates whether symmetric RTCP reports are
+            expected.";
         }
 
         leaf rtcp-feedback {
           type boolean;
-          description "A node that indicates whether the SIP service provider
-            supports the RTP profile extension for RTCP-based feedback
-            [@RFC4585]. Media sessions spanning enterprise and service
-            provider networks, are rarely made to flow directly between the
-            caller and callee, rather, it is often the case that media
-            traffic flows through network intermediaries such as SBCs. As a
-            result, RTCP traffic from the service provider network is
-            intercepted by these intermediaries, which in turn can either pass
-            across RTCP traffic unmodified or modify RTCP traffic before it
-            is forwarded to the endpoint in the enterprise network.
-            Modification of RTCP traffic would be required, for example, if
-            the intermediary has performed media payload transformation
-            operations such as transcoding or transrating. In a similar vein,
-            for the RTCP-based feedback mechanism as defined in [@RFC4585]
-            to be truly effective, intermediaries must ensure that feedback
-            messages are passed reliably and with the correct formatting to
-            enterprise endpoints. This might require additional configuration
-            and considerations that need to be dealt with at the time of
-            provisioning the intermediary device. This node is of boolean
-            type, a value of true indicates that the service provider supports
-            the RTP profile extension for RTP-based feedback and a value of
-            false indicates that the service provider does not support the RTP
-            profile extension for RTP-based feedback.";
+          description "Indicates whether the service provider
+            supports RTCP-based feedback.";
         }
       }
     }
 
     container dtmf {
-      description "A container that describes the various aspects of DTMF
-        relay via RTP Named Telephony Events. The dtmf container allows SIP
-        service providers to specify two facets of DTMF relay via Named
-        Telephony Events.";
+      description "Describes various aspects of DTMF relay via RTP
+        Named Telephony Events.";
 
       leaf payload-number {
         type uint8 {
           range "96..127";
         }
-        description "A node that indicates tht payload type number.";
+        description "Indicates the payload type number.";
       }
 
       leaf iteration {
         type boolean;
-        description "A node that indicates support for [@RFC2833] or
-          [@RFC4733]. SIP service providers can indicate support for
-          [@RFC4733] by setting the iteration flag to true or indicating
-          support for [@RFC2833] by setting the iteration flag to false.";
+        description "Indicates support for RFC2833 (false) or
+          RFC4733 (true).";
       }
     }
 
     container security {
-      description "A container that encapsulates characteristics about
-        encrypting signalling streams between the enterprise and SIP service
-        provider networks.";
+      description "Encapsulates characteristics about encrypting
+        signalling streams.";
 
       container signaling {
-        description "A container that encapsulates the type of security
-          protocol for the SIP communication between the enterprise SBC and
-          the service provider.";
+        description "Encapsulates the security protocol for SIP
+          signalling.";
 
         leaf secure {
           type boolean;
-          description "A node that specifies whether the service provider
-            allows the use of TLS to secure SIP signalling messages between
-            the enterprise and service provider network. This node is of
-            boolean type, a value of true indicates that the service provider
-            supports SIP sessions over TLS, wheras a value of false indicates
-            that the service provider does not support SIP over TLS.";
+          description "Specifies whether the service provider allows
+            the use of TLS for SIP signalling.";
         }
 
         leaf-list version {
@@ -642,103 +548,72 @@ module ietf-sip-auto-peering {
               description "TLS version 1.3.";
             }
           }
-          description "A list that specifies the version(s) of TLS supported.
-            If the service provider does not support TLS for protecting SIP
-            sessions, the signalling element is set to the string 'NULL'.";
+          description "Specifies the TLS version(s) supported. If
+            TLS is not supported, this list should be set to
+            'NULL'.";
         }
       }
 
       container media-security {
-        description "A container that describes the various characteristics
-          of securing media streams between enterprise and service provider
-          networks.";
+        description "Describes characteristics of securing media
+          streams.";
 
         leaf key-management {
-          type string {
-            pattern "(SDES(;DTLS-SRTP,version=[1-9]\\.[0-9](,[1-9]"
-            + "\\.[0-9])?)?)|(DTLS-SRTP,version=[1-9]\\.[0-9](,"
-            + "[1-9]\\.[0-9])?)|(NULL)";
+          type enumeration {
+            enum SDES {
+              description "Media security using SDES.";
+            }
+
+            enum DTLS-SRTP {
+              description "Media security using DTLS-SRTP.";
+            }
+
+            enum NULL {
+              description "No media security supported.";
+            }
           }
-          description "A node that specifies the key management method used
-            by the service provider. Possible values of this node include:
-            'SDES' and 'DTLS-SRTP'. A value of 'SDES' signifies that the SIP
-            service provider uses the methods defined in [@RFC4568] for the
-            purpose of key management. A value of 'DTLS-SRTP' signifies that
-            the SIP service provider uses the methods defined in [@RFC5764]
-            for the purpose of key management. If the value of this node is
-            set to 'DTLS-SRTP', the various versions of DTLS supported by the
-            SIP service provider MUST be encoded as per the formatting rules
-            of Section 7.2 If the service provider does not support media
-            security, the key-management node MUST be set to 'NULL'.";
+          description "Specifies the key management method used.
+            Possible values include 'SDES', 'DTLS-SRTP', or
+            'NULL'.";
         }
       }
 
       leaf cert-location {
         type string;
-        description "An optional node. If the enterprise network is required
-          to exchange SIP traffic over TLS with the SIP service provider, and
-          if the SIP service provider is capable of accepting TLS connections
-          from the enterprise network, it may be required for the SIP service
-          provider certificates to be pre-installed on the enterprise edge
-          element. In such situations, the cert-location node is populated
-          with a URL, which when dereferenced, provides a single PEM encoded
-          file that contains all certificates in the chain of trust.";
+        description "If required, contains the URL from which the
+          service provider's certificate(s) can be retrieved.";
       }
 
       container secure-telephony-identity {
-        description "A container that is used to collectively encapsulate
-          Secure Telephony Identity Revisited (STIR) characteristics.";
+        description "Encapsulates Secure Telephony Identity (STIR)
+          characteristics.";
 
         leaf stir-compliance {
           type boolean;
-          description "A node that indicates whether the SIP service provider
-            is STIR compliant. This node is of boolean type, a value of true
-            indicates that the SIP service provider is STIR compliant. A
-            value of false indicates that the SIP service provider is not
-            STIR compliant. A SIP service provider being STIR compliant has
-            implications for inbound and outbound calls, from the perspective
-            of the enterprise network.";
+          description "Indicates whether the service provider is
+            STIR compliant.";
         }
 
         leaf cert-delegation {
           type boolean;
-          description "A node that indicates whether a SIP service provider
-            that allocates one or more number ranges to an enterprise network,
-            is willing to delegate authority to the enterprise network over
-            that number range(s). This node is of boolean type, a value of
-            true indicates that the SIP service provider is willing to
-            delegate authority to the enterprise network over one or more
-            number ranges. A value of false indicates that the SIP service
-            provider is not willing to delegate authority to the enterprise
-            network over one or more number ranges. This node MUST only be
-            included in the capability set if the value of the stir-compliance
-            leaf node is set to true. In order to obtain delegate
-            certificates, the enterprise network must be made aware of the
-            scope of delegation - the number or number range(s) over which the
-            SIP service provider is willing to delegate authority. This
-            information is included in the num-ranges container.";
+          description "Indicates whether the service provider is
+            willing to delegate authority over allocated number
+            ranges.";
         }
 
         leaf acme-directory {
           when "../cert-delegation = 'true'";
-          type string;
-          description "A node that provides the URL of the directory object
-            for delegate certificates using Automatic Certificate Management
-            Environment (ACME) [@RFC8555]. The directory object URL, when 
-            de-referenced, provides a collection of field name-value pairs.
-            Certain field name-value pairs provided in the response are used
-            to bootstrap the process the obtaining delegate certificates. This
-            node MUST only be included in the capability set if the value of
-            the cert-delegation leaf node is set to true.";
+          type uri;
+          description "Provides the URL of the ACME directory for
+            delegate certificates.";
         }
       }
     }
 
     leaf-list extensions {
       type string;
-      description "A list of all possible SIP option tags supported by the
-        service provider network. These extensions must be referenced using
-        name registered under IANA.";
+      description "A list of all possible SIP option tags supported
+        by the service provider network.";
     }
   }
 }


### PR DESCRIPTION
Fixed the comments on yang module and updated the tree and example json. Only one error is left.

```
$ pyang --strict --ietf ietf-sip-auto-peering@2025-03-04.yang
ietf-sip-auto-peering@2025-03-04.yang:92: error: RFC 8407: 4.10: top-level node peering-info must not be mandatory
```